### PR TITLE
Improve message output in google activity

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--colour
+--require spec_helper

--- a/lib/lita/google_activity.rb
+++ b/lib/lita/google_activity.rb
@@ -32,5 +32,12 @@ module Lita
     def to_msg
       "#{@time.iso8601} #{@actor} #{@name}: #{@params.inspect}"
     end
+
+    def values
+      @params.map do |key, value|
+        "#{value} (#{key.downcase.gsub('_', ' ')})"
+      end.join(' to ')
+    end
+
   end
 end

--- a/lib/lita/google_activity.rb
+++ b/lib/lita/google_activity.rb
@@ -30,7 +30,11 @@ module Lita
     end
 
     def to_msg
-      "#{@time.iso8601} #{@actor} #{@name}: #{@params.inspect}"
+      <<~EOF
+        Date: #{@time.httpdate}
+        Admin User: #{@actor}
+        Action: #{@name.capitalize.gsub('_', ' ')} => #{values}
+      EOF
     end
 
     def values

--- a/lita-googleapps.gemspec
+++ b/lita-googleapps.gemspec
@@ -18,5 +18,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("rdoc")
 
   spec.add_dependency('lita-timing', '~>0.1')
+  spec.add_dependency('lita')
   spec.add_dependency('google-api-client', '~>0.8.0')
 end

--- a/spec/google_activity_spec.rb
+++ b/spec/google_activity_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Lita::GoogleActivity do
+  let(:activity) { Lita::GoogleActivity.new(
+    time: Time.utc(2016, 6, 14, 2, 27, 48),
+    actor: "ellie@hi.com",
+    ip: "1.1.1.1",
+    name: "ADD_GROUP_MEMBER",
+    params: {
+      "USER_EMAIL"=>"rafael.sarralde@theconversation.com", "GROUP_EMAIL"=>"spain@theconversation.com"
+    }
+  )}
+  describe "#to_msg" do
+    it "returns helpful string" do
+      expect(activity.to_msg).to eq '2016-06-14T02:27:48Z ellie@hi.com ADD_GROUP_MEMBER: {"USER_EMAIL"=>"rafael.sarralde@theconversation.com", "GROUP_EMAIL"=>"spain@theconversation.com"}'
+    end
+  end
+end

--- a/spec/google_activity_spec.rb
+++ b/spec/google_activity_spec.rb
@@ -5,14 +5,20 @@ describe Lita::GoogleActivity do
     time: Time.utc(2016, 6, 14, 2, 27, 48),
     actor: "ellie@hi.com",
     ip: "1.1.1.1",
-    name: "ADD_GROUP_MEMBER",
+    name: "Add group member",
     params: {
-      "USER_EMAIL"=>"rafael.sarralde@theconversation.com", "GROUP_EMAIL"=>"spain@theconversation.com"
+      "USER_EMAIL"=>"foo@bar.com", "GROUP_EMAIL"=>"bargroup@foo.com"
     }
   )}
   describe "#to_msg" do
     it "returns helpful string" do
-      expect(activity.to_msg).to eq '2016-06-14T02:27:48Z ellie@hi.com ADD_GROUP_MEMBER: {"USER_EMAIL"=>"rafael.sarralde@theconversation.com", "GROUP_EMAIL"=>"spain@theconversation.com"}'
+      expect(activity.to_msg).to eq(
+        <<~EOF
+          Date: Tue, 14 Jun 2016 02:27:48 GMT
+          Admin User: ellie@hi.com
+          Action: Add group member => foo@bar.com (user email) to bargroup@foo.com (group email)
+        EOF
+      )
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require "lita-googleapps"
+require "lita/rspec"
+Lita.version_3_compatibility_mode = false


### PR DESCRIPTION
Google activity output is fine to read for a rubyist, but not so much for the administrators. This PR improves the output to a more readable format by extracting the params to their own method. Also, specs